### PR TITLE
Leptos route switch bug

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -78,6 +78,7 @@ fn Things(cx: Scope) -> impl IntoView {
     view! { cx,
         <Header1>"Things"</Header1>
         <div class="items-left">
+            <ThingsNav/>
             <Outlet/>
         </div>
     }
@@ -125,7 +126,6 @@ fn ThingsList(cx: Scope) -> impl IntoView {
     view! { cx,
         <Header2>"List of things"</Header2>
 
-        <ThingsNav/>
         <div>
             <Link link="/" text="Main page"/>
         </div>
@@ -139,7 +139,6 @@ fn ThingView(cx: Scope) -> impl IntoView {
 
     let things = create_resource(cx, move || (), move |_| read_things());
     view! { cx,
-        <ThingsNav/>
         <Header2>"Thing: " {id}</Header2>
         <SuspenseWithErrorHandling>
             {move || {


### PR DESCRIPTION
## How to reproduce

1. Clone this PR
2. Run `cargo leptos watch`
3. Open http://localhost:3000/things in browser (`/things` is important)
4. You'll see a list of 4 "things". Clicking on any of them should switch to the sub route, but ... nothing happens.

This problem does not exist on the `master` branch.

## Screenshots

What you'll continue to see upon clicking any of those 4 links when the bug is active:

<img width="191" alt="image" src="https://github.com/srid/leptos-fullstack/assets/3998/e641c3f4-b6fb-424f-8986-df8961273d7e">

What you should see when clicking on, say, "Thing 2", when the bug is **not** active (as when using the `master` branch):

<img width="339" alt="image" src="https://github.com/srid/leptos-fullstack/assets/3998/b2c9c4d7-0d2b-4764-b9fa-1ffcddcb29d2">

